### PR TITLE
[fix] Use correct whisper model_id

### DIFF
--- a/utils/run_wer.py
+++ b/utils/run_wer.py
@@ -21,7 +21,7 @@ lang = sys.argv[3] # zh or en
 device = "cuda" if torch.cuda.is_available() else 'cpu'
 
 def load_en_model():
-    model_id = "whisper-large-v3/large-v3.pt"
+    model_id = "large-v3"
     model = whisper.load_model(model_id).to(device)
     model.eval()
     return model


### PR DESCRIPTION
According to the definition of the load_model api in openai-whisper, the model_id should not be an absolute path.

https://github.com/openai/whisper/blob/main/whisper/__init__.py#L17-L32